### PR TITLE
Changes to allow ICOFamily to run under 10.5

### DIFF
--- a/ICOFamily.m
+++ b/ICOFamily.m
@@ -91,7 +91,7 @@
 		return;
 	if (size.width<=0||size.height>256||size.height<=0||size.width>256)
 		return; // Maximum dimensions
-	[elements setObject:[rep bitmapImageRepByConvertingToColorSpace:[NSColorSpace genericRGBColorSpace] 
+	[elements setObject:[rep bitmapImageRepByConvertingToColorSpace:[NSColorSpace genericRGBColorSpace]		// NOT IN 10.5
 													renderingIntent:NSColorRenderingIntentPerceptual] forKey:NSStringFromSize(size)];
 }
 - (void)setData:(NSData*)data forCustomSize:(NSSize)size {
@@ -230,14 +230,14 @@
 	if (!rep)
 		return;
 	if ((element & kICOFamilyAllElements)==kICOFamilyAllElements) {
-		[self setElements:element fromImage:[[[NSImage alloc] initWithCGImage:rep.CGImage 
+		[self setElements:element fromImage:[[[NSImage alloc] initWithCGImage:rep.CGImage 	// NOT IN 10.5
 																		 size:NSMakeSize(rep.pixelsWide, rep.pixelsHigh)]
 											 autorelease]];
 		return;
 	}
 	if ([self verifyImageOfSize:NSMakeSize(rep.pixelsWide, rep.pixelsHigh) 
 					 forElement:element])
-		[elements setObject:[rep bitmapImageRepByConvertingToColorSpace:[NSColorSpace genericRGBColorSpace] 
+		[elements setObject:[rep bitmapImageRepByConvertingToColorSpace:[NSColorSpace genericRGBColorSpace] 	// NOT IN 10.5
 														renderingIntent:NSColorRenderingIntentPerceptual] forKey:[NSNumber numberWithInteger:element]];
 }
 - (void)setData:(NSData*)data forElement:(kICOFamilyElement)element {
@@ -308,8 +308,8 @@
 	NSMutableData *headers = [[NSMutableData alloc] init];
 	NSMutableData *images = [[NSMutableData alloc] init];
 	
-	NSSortDescriptor *high = [NSSortDescriptor sortDescriptorWithKey:@"pixelsHigh" ascending:NO];
-	NSSortDescriptor *pixelsWide = [NSSortDescriptor sortDescriptorWithKey:@"pixelsWide" ascending:NO];
+	NSSortDescriptor *high = [NSSortDescriptor sortDescriptorWithKey:@"pixelsHigh" ascending:NO];		// NOT IN 10.5
+	NSSortDescriptor *pixelsWide = [NSSortDescriptor sortDescriptorWithKey:@"pixelsWide" ascending:NO];		// NOT IN 10.5
 		// Sort it so it is pretty
 	NSArray *vals = [elements.allValues sortedArrayUsingDescriptors:[NSArray arrayWithObjects:
 																	 high, pixelsWide, nil]];

--- a/ICOFamily.m
+++ b/ICOFamily.m
@@ -337,17 +337,15 @@
 		int iheight=currentRep.pixelsHigh;
 		if (iheight==256)
 			iheight=0;
-		const char *width = [[NSString stringWithFormat:@"%i", iwidth] UTF8String];
-		const char *height = [[NSString stringWithFormat:@"%i", iheight] UTF8String];
-		const char *palette = "0";
-		const char *reserved = "0";
+		const char palette = 0;
+		const char reserved = 0;
 		short planes = currentRep.numberOfPlanes;
 		short bpp = currentRep.bitsPerPixel; // bits per pixel
 		int size = bitmapData.length;
-		[headers appendBytes:width length:sizeof(const char)]; // 0 - 255 and 0 = 256
-		[headers appendBytes:height length:sizeof(const char)]; // 0 - 255 and 0 = 256
-		[headers appendBytes:palette length:sizeof(const char)];
-		[headers appendBytes:reserved length:sizeof(const char)];
+		[headers appendBytes:&iwidth length:sizeof(const char)]; // 0 - 255 and 0 = 256
+		[headers appendBytes:&iheight length:sizeof(const char)]; // 0 - 255 and 0 = 256
+		[headers appendBytes:&palette length:sizeof(const char)];
+		[headers appendBytes:&reserved length:sizeof(const char)];
 		[headers appendBytes:&planes length:sizeof(short)];
 		[headers appendBytes:&bpp length:sizeof(short)];
 		[headers appendBytes:&size length:sizeof(int)];

--- a/ICOFamily.m
+++ b/ICOFamily.m
@@ -95,9 +95,9 @@
 	if ([rep respondsToSelector:@selector(bitmapImageRepByConvertingToColorSpace:renderingIntent:)])	// 10.6+ runtime only
 	{
 		rep = [rep bitmapImageRepByConvertingToColorSpace:[NSColorSpace genericRGBColorSpace]
-										 renderingIntent:NSColorRenderingIntentPerceptual]
+                                          renderingIntent:NSColorRenderingIntentPerceptual];
 	}
-	[elements setObject:convertedRep forKey:NSStringFromSize(size)];
+	[elements setObject:rep forKey:NSStringFromSize(size)];
 }
 - (void)setData:(NSData*)data forCustomSize:(NSSize)size {
 	if (!data)
@@ -247,7 +247,7 @@
 		if ([rep respondsToSelector:@selector(bitmapImageRepByConvertingToColorSpace:renderingIntent:)])	// 10.6+ runtime only
 		{
 			rep = [rep bitmapImageRepByConvertingToColorSpace:[NSColorSpace genericRGBColorSpace]
-											  renderingIntent:NSColorRenderingIntentPerceptual]
+											  renderingIntent:NSColorRenderingIntentPerceptual];
 		}
 		[elements setObject:rep forKey:[NSNumber numberWithInteger:element]];
 	}

--- a/ICOFamily.m
+++ b/ICOFamily.m
@@ -91,8 +91,13 @@
 		return;
 	if (size.width<=0||size.height>256||size.height<=0||size.width>256)
 		return; // Maximum dimensions
-	[elements setObject:[rep bitmapImageRepByConvertingToColorSpace:[NSColorSpace genericRGBColorSpace]		// NOT IN 10.5
-													renderingIntent:NSColorRenderingIntentPerceptual] forKey:NSStringFromSize(size)];
+	
+	if ([rep respondsToSelector:@selector(bitmapImageRepByConvertingToColorSpace:renderingIntent:)])	// 10.6+ runtime only
+	{
+		rep = [rep bitmapImageRepByConvertingToColorSpace:[NSColorSpace genericRGBColorSpace]
+										 renderingIntent:NSColorRenderingIntentPerceptual]
+	}
+	[elements setObject:convertedRep forKey:NSStringFromSize(size)];
 }
 - (void)setData:(NSData*)data forCustomSize:(NSSize)size {
 	if (!data)
@@ -238,8 +243,14 @@
 	}
 	if ([self verifyImageOfSize:NSMakeSize(rep.pixelsWide, rep.pixelsHigh) 
 					 forElement:element])
-		[elements setObject:[rep bitmapImageRepByConvertingToColorSpace:[NSColorSpace genericRGBColorSpace] 	// NOT IN 10.5
-														renderingIntent:NSColorRenderingIntentPerceptual] forKey:[NSNumber numberWithInteger:element]];
+	{
+		if ([rep respondsToSelector:@selector(bitmapImageRepByConvertingToColorSpace:renderingIntent:)])	// 10.6+ runtime only
+		{
+			rep = [rep bitmapImageRepByConvertingToColorSpace:[NSColorSpace genericRGBColorSpace]
+											  renderingIntent:NSColorRenderingIntentPerceptual]
+		}
+		[elements setObject:rep forKey:[NSNumber numberWithInteger:element]];
+	}
 }
 - (void)setData:(NSData*)data forElement:(kICOFamilyElement)element {
 	if (!data)

--- a/ICOFamily.m
+++ b/ICOFamily.m
@@ -230,9 +230,10 @@
 	if (!rep)
 		return;
 	if ((element & kICOFamilyAllElements)==kICOFamilyAllElements) {
-		[self setElements:element fromImage:[[[NSImage alloc] initWithCGImage:rep.CGImage 	// NOT IN 10.5
-																		 size:NSMakeSize(rep.pixelsWide, rep.pixelsHigh)]
-											 autorelease]];
+		NSBitmapImageRep *bitmapRep = [[[NSBitmapImageRep alloc] initWithCGImage:rep.CGImage] autorelease];
+		NSImage *image = [[[NSImage alloc] init] autorelease];
+		[image addRepresentation:bitmapRep];
+		[self setElements:element fromImage:image];
 		return;
 	}
 	if ([self verifyImageOfSize:NSMakeSize(rep.pixelsWide, rep.pixelsHigh) 
@@ -308,8 +309,8 @@
 	NSMutableData *headers = [[NSMutableData alloc] init];
 	NSMutableData *images = [[NSMutableData alloc] init];
 	
-	NSSortDescriptor *high = [NSSortDescriptor sortDescriptorWithKey:@"pixelsHigh" ascending:NO];		// NOT IN 10.5
-	NSSortDescriptor *pixelsWide = [NSSortDescriptor sortDescriptorWithKey:@"pixelsWide" ascending:NO];		// NOT IN 10.5
+	NSSortDescriptor *high = [[[NSSortDescriptor alloc] initWithKey:@"pixelsHigh" ascending:NO] autorelease];
+	NSSortDescriptor *pixelsWide = [[[NSSortDescriptor alloc] initWithKey:@"pixelsWide" ascending:NO] autorelease];
 		// Sort it so it is pretty
 	NSArray *vals = [elements.allValues sortedArrayUsingDescriptors:[NSArray arrayWithObjects:
 																	 high, pixelsWide, nil]];


### PR DESCRIPTION
Hi, we just started using ICOFamily in new versions of Sandvox.  Unfortunately we discovered a lot of reports from our beta testers running 10.5 that this code contains a few calls to methods that are not in AppKit until 10.6.  I was able to make just a few changes to work around this.  The only loss in functionality when running under 10.5, compared to 10.6, is that we aren't able to convert the color space to _generic_ RGB as the 10.6 code does.  Still, it's better than not functioning at all!
